### PR TITLE
Exception: Undefined index: details in FcmErrorException@cast

### DIFF
--- a/src/FCM/Exceptions/FcmErrorException.php
+++ b/src/FCM/Exceptions/FcmErrorException.php
@@ -53,15 +53,16 @@ abstract class FcmErrorException extends Exception
     static function cast(RequestException $e){
         $response = $e->getResponse();
         $json = json_decode($response->getBody(),true);
+
         if(!$json || empty($json['error']['status'])){
             //Not a valid FcmError
             return $e;
         }
 
-        $status = $json['error']['status'];
-        $code = $json['error']['code'];
-        $message = $json['error']['message'];
-        $details = $json['error']['details'];
+        $status = isset($json['error']['status']) ? $json['error']['status'] : '';
+        $code = isset($json['error']['code']) ? $json['error']['code'] : '';
+        $message = isset($json['error']['message']) ? $json['error']['message'] : '';
+        $details = isset($json['error']['details']) ? $json['error']['details'] : '';
 
         switch ($status){
             default:

--- a/src/FCM/Exceptions/FcmErrorException.php
+++ b/src/FCM/Exceptions/FcmErrorException.php
@@ -60,9 +60,9 @@ abstract class FcmErrorException extends Exception
         }
 
         $status = $json['error']['status'];
-        $code = isset($json['error']['code']) ? $json['error']['code'] : '';
-        $message = isset($json['error']['message']) ? $json['error']['message'] : '';
-        $details = isset($json['error']['details']) ? $json['error']['details'] : '';
+        $code = isset($json['error']['code']) ? $json['error']['code'] : 0;
+        $message = isset($json['error']['message']) ? $json['error']['message'] : null;
+        $details = isset($json['error']['details']) ? $json['error']['details'] : null;
 
         switch ($status){
             default:

--- a/src/FCM/Exceptions/FcmErrorException.php
+++ b/src/FCM/Exceptions/FcmErrorException.php
@@ -59,7 +59,7 @@ abstract class FcmErrorException extends Exception
             return $e;
         }
 
-        $status = isset($json['error']['status']) ? $json['error']['status'] : '';
+        $status = $json['error']['status'];
         $code = isset($json['error']['code']) ? $json['error']['code'] : '';
         $message = isset($json['error']['message']) ? $json['error']['message'] : '';
         $details = isset($json['error']['details']) ? $json['error']['details'] : '';


### PR DESCRIPTION
I have an error in `FcmErrorException@cast`: "`Undefined index: details`", and that's a bad situation because the original RequestException is lost. So I guess adding default values for error info params is the easy solution while only "status" is the necessary one.