### PR TITLE
handle null response

### DIFF
--- a/src/FCM/Exceptions/FcmErrorException.php
+++ b/src/FCM/Exceptions/FcmErrorException.php
@@ -52,6 +52,9 @@ abstract class FcmErrorException extends Exception
      */
     static function cast(RequestException $e){
         $response = $e->getResponse();
+        if (empty($response)){
+            return $e;
+        }
         $json = json_decode($response->getBody(),true);
 
         if(!$json || empty($json['error']['status'])){


### PR DESCRIPTION
Sometimes the Request suffers such error that there is no Response (eg timeout) 
The getResponse() methud returns null and the calling getBody() on null leads to another exception.