### PR TITLE
return UnspecifiedErrorException for unknown FCM errors

### DIFF
--- a/src/FCM/Exceptions/FcmErrorException.php
+++ b/src/FCM/Exceptions/FcmErrorException.php
@@ -64,9 +64,7 @@ abstract class FcmErrorException extends Exception
         $message = isset($json['error']['message']) ? $json['error']['message'] : null;
         $details = isset($json['error']['details']) ? $json['error']['details'] : null;
 
-        switch ($status){
-            default:
-                return $e;
+        switch ($status){            
             case 'UNSPECIFIED_ERROR':
                 return new UnspecifiedErrorException($status,$code,$message,$details);
             case 'INVALID_ARGUMENT':
@@ -83,6 +81,10 @@ abstract class FcmErrorException extends Exception
                 return new UnavailableException($status,$code,$message,$details);
             case 'INTERNAL':
                 return new InternalException($status,$code,$message,$details);
+            case null:
+                return $e;
+            default:
+                return new UnspecifiedErrorException($status,$code,$message,$details);;
 
         }
     }


### PR DESCRIPTION
In some cases responses and status codes may be subject to change. If there is a new type of FCM error, the current version returns the RequestException unchanged, while the response clearly contains the details of FCM error, it just doesn't have it's own dedicated exception class.
Return RequestException only if the response doesn't match the expected FCM response structure.