### PR TITLE
Re-Use HTTP-Client for mutliple FCM-Requests

### DIFF
--- a/src/ServiceAccount.php
+++ b/src/ServiceAccount.php
@@ -59,9 +59,9 @@ class ServiceAccount
     }
 
     /**
-     * Authorize an http request
+     * Create a Http Client with required Authorization
      * @param array|string $scope Scope of the requested credentials @see https://developers.google.com/identity/protocols/googlescopes
-     * @param ClientInterface|null $request
+     * @param ClientInterface|null $request Copy options from this client
      * @return ClientInterface
      */
     function authorize($scope,ClientInterface $request=null){


### PR DESCRIPTION
Hi!

Sending multiple Messages was very slow for me (45 mins for ~6000 targets) with this patch I've got it down to 5 minutes.
This getClient() is basically the same like in Database.php - so making it similar.

In addition I've changed the comments because they seem misleading.